### PR TITLE
use existing _id if present when creating document

### DIFF
--- a/spec/couchdb_spec.cr
+++ b/spec/couchdb_spec.cr
@@ -100,8 +100,11 @@ describe CouchDB do
 
     it "should get a document" do
       client = new_client
-      new_doc = client.create_document("testdb", {name: "John", age: 20})
-      result = client.get_document("testdb", new_doc.id.not_nil!, Hash(String, JSON::Any))
+      status = client.create_document("testdb", {_id: "john", name: "John", age: 20})
+      status.ok?.should be_true
+      status.id.should eq "john"
+
+      result = client.get_document("testdb", "john", Hash(String, JSON::Any))
       result.should_not be_nil
       result.not_nil!.values_at("name", "age").should eq({"John", 20})
       result.not_nil!["_id"].should_not be_nil

--- a/src/couchdb/client.cr
+++ b/src/couchdb/client.cr
@@ -71,7 +71,12 @@ module CouchDB
     end
 
     def create_document(database, object) : Response::DocumentStatus
-      uuid = new_uuids.first
+      existing_id = case object
+        when .responds_to?(:_id) then object._id
+        when .responds_to?(:[]?) then object["_id"]? || object[:_id]?
+      end
+
+      uuid = existing_id || new_uuids.first
       Response::DocumentStatus.from_json(
         put(URL::DOC % {database, uuid}, body: object.to_json)
       )


### PR DESCRIPTION
I found this helpful in my own app. But I'm new to CouchDB, so let me know if this is not a good practice.