### PR TITLE
updated for Crystal 0.35.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 -fork of TechMagister/couchdb.cr
-- added custom method to client.cr for using externally-generated ID:  create_document_custom_id(database, object, id)
+- fixed "sort"
 - updated for crystal 0.35.1 (will update for v1 shortly...circleCI = never. tests updated = shortly)
 - 
 CouchDB client written in crystal

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# couchdb [![Build Status on CircleCI](https://circleci.com/gh/TechMagister/couchdb.cr.svg?style=svg)](https://circleci.com/gh/TechMagister/couchdb.cr)
+-fork of TechMagister/couchdb.cr
+- added custom method to client.cr for using externally-generated ID:  create_document_custom_id(database, object, id)
+
 CouchDB client written in crystal
 
 ## Installation
@@ -8,7 +10,7 @@ Add this to your application's `shard.yml`:
 ```yaml
 dependencies:
   couchdb:
-    github: TechMagister/couchdb.cr
+    github: vectorselector/couchdb.cr
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -29,10 +29,11 @@ info.vendor.name # The Apache Software Foundation
 ```
 
 usage overview/example:
-`COUCHDB_URL = ENV["COUCHDB_URL"]? || "http://127.0.0.1:5984"`
-`DB = CouchDB::Client.new COUCHDB_URL` 
-`myQuery = CouchDB::FindQuery.from_json %({"selector":{"user_id":"#{userId}", "$not":{"archived":true} }, "sort":[{"timestamp":"desc"}], "limit":#{limit} })`
-`myThing = DB.find_document("things", myQuery).docs.not_nil!.first`
+```COUCHDB_URL = ENV["COUCHDB_URL"]? || "http://127.0.0.1:5984"
+`DB = CouchDB::Client.new COUCHDB_URL
+`myQuery = CouchDB::FindQuery.from_json %({"selector":{"user_id":"#{userId}", "$not":{"archived":true} }, "sort":[{"timestamp":"desc"}], "limit":#{limit} })
+`myThing = DB.find_document("things", myQuery).docs.not_nil!.first
+ ```
  
 "sort" takes an array of  EITHER a String or an object as such [{"fieldname1": "desc"}, {"fieldname2": "asc"}] per CouchDB docs
 https://docs.couchdb.org/en/2.3.1/api/database/find.html#sort-syntax

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 -fork of TechMagister/couchdb.cr
 - added custom method to client.cr for using externally-generated ID:  create_document_custom_id(database, object, id)
-- updated for crystal 0.35.1 *
-  
+- updated for crystal 0.35.1 (will update for v1 shortly...circleCI = never. tests updated = shortly)
+- 
 CouchDB client written in crystal
 
 ## Installation
@@ -28,6 +28,17 @@ info.vendor.name # The Apache Software Foundation
 
 ```
 
+usage overview/example:
+`COUCHDB_URL = ENV["COUCHDB_URL"]? || "http://127.0.0.1:5984"`
+`DB = CouchDB::Client.new COUCHDB_URL` 
+`myQuery = CouchDB::FindQuery.from_json %({"selector":{"user_id":"#{userId}", "$not":{"archived":true} }, "sort":[{"timestamp":"desc"}], "limit":#{limit} })`
+`myThing = DB.find_document("things", myQuery).docs.not_nil!.first`
+ 
+"sort" takes an array of  EITHER a String or an object as such [{"fieldname1": "desc"}, {"fieldname2": "asc"}] per CouchDB docs
+https://docs.couchdb.org/en/2.3.1/api/database/find.html#sort-syntax
+
+"skip" is like "limit" and goes outside the "selector"...
+
 ## Development
 
 - [x] Get server info
@@ -50,20 +61,9 @@ info.vendor.name # The Apache Software Foundation
 5. Create a new Pull Request
 
 ## Original Project Contributors (what I've forked)
-
 - [TechMagister](https://github.com/TechMagister) Arnaud Fernandés - creator, maintainer
 - [Schniz](https://github.com/Schniz) Gal Schlezinger - contributor
 
 
-*among other minor API changes JSON.mapping is deprecated, instead we do the following:
-```
-  class FindQuery
-    include JSON::Serializable
-    property selector : JSON::Any
-    property limit : Int64?
-    property skip : Int64?
-    property sort : Array(String)?
-    property fields : Array(String)?
-  end
-```
+
 

--- a/README.md
+++ b/README.md
@@ -29,10 +29,11 @@ info.vendor.name # The Apache Software Foundation
 ```
 
 usage overview/example:
-```COUCHDB_URL = ENV["COUCHDB_URL"]? || "http://127.0.0.1:5984"
-`DB = CouchDB::Client.new COUCHDB_URL
-`myQuery = CouchDB::FindQuery.from_json %({"selector":{"user_id":"#{userId}", "$not":{"archived":true} }, "sort":[{"timestamp":"desc"}], "limit":#{limit} })
-`myThing = DB.find_document("things", myQuery).docs.not_nil!.first
+```
+COUCHDB_URL = ENV["COUCHDB_URL"]? || "http://127.0.0.1:5984"
+DB = CouchDB::Client.new COUCHDB_URL
+myQuery = CouchDB::FindQuery.from_json %({"selector":{"user_id":"#{userId}", "$not":{"archived":true} }, "sort":[{"timestamp":"desc"}], "limit":#{limit} })
+myThing = DB.find_document("things", myQuery).docs.not_nil!.first
  ```
  
 "sort" takes an array of  EITHER a String or an object as such [{"fieldname1": "desc"}, {"fieldname2": "asc"}] per CouchDB docs

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 -fork of TechMagister/couchdb.cr
 - added custom method to client.cr for using externally-generated ID:  create_document_custom_id(database, object, id)
-
+- updated for crystal 0.35.1 *
+  
 CouchDB client written in crystal
 
 ## Installation
@@ -52,3 +53,17 @@ info.vendor.name # The Apache Software Foundation
 
 - [TechMagister](https://github.com/TechMagister) Arnaud Fernandés - creator, maintainer
 - [Schniz](https://github.com/Schniz) Gal Schlezinger - contributor
+
+
+*among other minor API changes JSON.mapping is deprecated, instead we do the following:
+```
+  class FindQuery
+    include JSON::Serializable
+    property selector : JSON::Any
+    property limit : Int64?
+    property skip : Int64?
+    property sort : Array(String)?
+    property fields : Array(String)?
+  end
+```
+

--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ info.vendor.name # The Apache Software Foundation
 
 ## Contributing
 
-1. Fork it ( https://github.com/TechMagister/couchdb/fork )
+1. Fork it ( https://github.com/vectorselector/couchdb/fork )
 2. Create your feature branch (git checkout -b my-new-feature)
 3. Commit your changes (git commit -am 'Add some feature')
 4. Push to the branch (git push origin my-new-feature)
 5. Create a new Pull Request
 
-## Contributors
+## Original Project Contributors (what I've forked)
 
 - [TechMagister](https://github.com/TechMagister) Arnaud Fernandés - creator, maintainer
 - [Schniz](https://github.com/Schniz) Gal Schlezinger - contributor

--- a/shard.yml
+++ b/shard.yml
@@ -5,6 +5,6 @@ authors:
   - Arnaud Fernandés <arnaud.fernandes@tech-magister.com>
   - fork maintained by vectorselector
 
-crystal: 0.35.1
+crystal: 1.0.0
 
 license: MIT

--- a/shard.yml
+++ b/shard.yml
@@ -1,8 +1,9 @@
 name: couchdb
-version: 0.2.0
+version: 0.3.0
 
 authors:
   - Arnaud Fernandés <arnaud.fernandes@tech-magister.com>
+  - fork maintained by vectorselector
 
 crystal: 0.35.1
 

--- a/shard.yml
+++ b/shard.yml
@@ -5,6 +5,6 @@ authors:
   - Arnaud Fernandés <arnaud.fernandes@tech-magister.com>
   - fork maintained by vectorselector
 
-crystal: 1.0.0
+crystal: 0.35.1
 
 license: MIT

--- a/shard.yml
+++ b/shard.yml
@@ -4,6 +4,6 @@ version: 0.2.0
 authors:
   - Arnaud Fernandés <arnaud.fernandes@tech-magister.com>
 
-crystal: 0.20.4
+crystal: 0.35.1
 
 license: MIT

--- a/src/couchdb/client.cr
+++ b/src/couchdb/client.cr
@@ -77,6 +77,12 @@ module CouchDB
       )
     end
 
+    def create_document_custom_id(database, object, id) : Response::DocumentStatus
+      Response::DocumentStatus.from_json(
+        put(URL::DOC % {database, id}, body: object.to_json)
+      )
+    end 
+    
     def delete_document(database, uuid, rev) : Response::DocumentStatus
       Response::DocumentStatus.from_json(
         delete(URL::DOC % {database, uuid} + "?rev=#{rev}")

--- a/src/couchdb/find_query.cr
+++ b/src/couchdb/find_query.cr
@@ -8,7 +8,7 @@ module CouchDB
     property selector : JSON::Any
     property limit : Int64?
     property skip : Int64?
-    property sort : Array(String)?
+    property sort : Array(String)? | JSON::Any?
     property fields : Array(String)?
 
   end

--- a/src/couchdb/find_query.cr
+++ b/src/couchdb/find_query.cr
@@ -4,13 +4,13 @@ module CouchDB
 
   class FindQuery
 
-    JSON.mapping(
-      selector: JSON::Any,
-      limit: Int64?,
-      skip: Int64?,
-      sort: Array(String)?,
-      fields: Array(String)?
-    )
+    {
+      "selector" => JSON::Any,
+      "limit" => Int64?,
+      "skip" => Int64?,
+      "sort" => Array(String)?,
+      "fields" => Array(String)?
+    }.to_json
 
   end
 

--- a/src/couchdb/find_query.cr
+++ b/src/couchdb/find_query.cr
@@ -3,14 +3,13 @@ require "json"
 module CouchDB
 
   class FindQuery
-
-    {
-      "selector" => JSON::Any,
-      "limit" => Int64?,
-      "skip" => Int64?,
-      "sort" => Array(String)?,
-      "fields" => Array(String)?
-    }.to_json
+    include JSON::Serializable
+    
+    property selector : JSON::Any
+    property limit : Int64?
+    property skip : Int64?
+    property sort : Array(String)?
+    property fields : Array(String)?
 
   end
 

--- a/src/couchdb/response/active_task.cr
+++ b/src/couchdb/response/active_task.cr
@@ -7,7 +7,7 @@ module CouchDB::Response
       "change_done" => Int64,
       "database" => String,
       "pid" => String,
-      "progress" => Int32,
+      "progress" => Int,
       "started_on" => Int64,
       "total_changes" => Int64,
       "type" => String,

--- a/src/couchdb/response/active_task.cr
+++ b/src/couchdb/response/active_task.cr
@@ -3,16 +3,17 @@ require "json"
 module CouchDB::Response
 
   class ActiveTask
-    {
-      "change_done" => Int64,
-      "database" => String,
-      "pid" => String,
-      "progress" => Int64,
-      "started_on" => Int64,
-      "total_changes" => Int64,
-      "type" => String,
-      "updated_on" => Int64
-    }.to_json
+    include JSON::Serializable
+    
+    property change_done : Int64
+    property database : String
+    property pid : String
+    property progress : Int64
+    property started_on : Int64
+    property total_changes : Int64
+    property type : String
+    property updated_on : Int64
+    
   end
 
 end

--- a/src/couchdb/response/active_task.cr
+++ b/src/couchdb/response/active_task.cr
@@ -3,16 +3,16 @@ require "json"
 module CouchDB::Response
 
   class ActiveTask
-    JSON.mapping(
-      change_done: Int64,
-      database: String,
-      pid: String,
-      progress: Int32,
-      started_on: Int64,
-      total_changes: Int64,
-      type: String,
-      updated_on: Int64
-    )
+    {
+      "change_done" => Int64,
+      "database" => String,
+      "pid" => String,
+      "progress" => Int32,
+      "started_on" => Int64,
+      "total_changes" => Int64,
+      "type" => String,
+      "updated_on" => Int64
+    }.to_json
   end
 
 end

--- a/src/couchdb/response/active_task.cr
+++ b/src/couchdb/response/active_task.cr
@@ -7,7 +7,7 @@ module CouchDB::Response
       "change_done" => Int64,
       "database" => String,
       "pid" => String,
-      "progress" => Int,
+      "progress" => Int64,
       "started_on" => Int64,
       "total_changes" => Int64,
       "type" => String,

--- a/src/couchdb/response/results.cr
+++ b/src/couchdb/response/results.cr
@@ -4,12 +4,12 @@ module CouchDB::Response
 
   class Result
 
-    JSON.mapping(
-      id: String,
-      key: String,
-      value: NamedTuple(rev: String),
-      doc: JSON::Any?
-    )
+    {
+      "id" => String,
+      "key" => String,
+      "value" => NamedTuple(rev: String),
+      "doc" => JSON::Any?
+    }.to_json
 
     def [](key : String)
       if d = doc
@@ -23,21 +23,21 @@ module CouchDB::Response
 
   class Results
 
-    JSON.mapping(
-      total_rows: Int64,
-      offset: Int64,
-      rows: Array(Result)
-    )
+    {
+      "total_rows" => Int64,
+      "offset" => Int64,
+      "rows" => Array(Result)
+    }.to_json
 
   end
 
   class FindResults(T)
-    JSON.mapping(
-      error: String?,
-      reason: String?,
-      warning: String?,
-      docs: Array(T)?
-    )
+    {
+      "error" => String?,
+      "reason" => String?,
+      "warning" => String?,
+      "docs" => Array(T)?
+    }.to_json
 
     def ok?
       error ? false : true

--- a/src/couchdb/response/results.cr
+++ b/src/couchdb/response/results.cr
@@ -3,13 +3,11 @@ require "json"
 module CouchDB::Response
 
   class Result
-
-    {
-      "id" => String,
-      "key" => String,
-      "value" => NamedTuple(rev: String),
-      "doc" => JSON::Any?
-    }.to_json
+    include JSON::Serializable
+    property id : String
+    property key : String
+    property value : NamedTuple(rev: String)
+    property doc : JSON::Any?
 
     def [](key : String)
       if d = doc
@@ -22,22 +20,18 @@ module CouchDB::Response
   end
 
   class Results
-
-    {
-      "total_rows" => Int64,
-      "offset" => Int64,
-      "rows" => Array(Result)
-    }.to_json
-
+    include JSON::Serializable
+    property total_rows : Int64
+    property offset : Int64
+    property rows : Array(Result)
   end
 
   class FindResults(T)
-    {
-      "error" => String?,
-      "reason" => String?,
-      "warning" => String?,
-      "docs" => Array(T)?
-    }.to_json
+    include JSON::Serializable
+    property error : String?
+    property reason : String?
+    property warning : String?
+    property docs : Array(T)?
 
     def ok?
       error ? false : true

--- a/src/couchdb/response/server_info.cr
+++ b/src/couchdb/response/server_info.cr
@@ -3,19 +3,19 @@ require "json"
 module CouchDB::Response
 
   class Vendor
-    JSON.mapping(
-      name: String,
-      version: String?
-    )
+    {
+      "name" => String,
+      "version" => String?
+    }.to_json
   end
 
   class ServerInfo
-    JSON.mapping(
-      couchdb: String,
-      uuid: String?,
-      version: String,
-      vendor: Vendor
-    )
+    {
+      "couchdb" => String,
+      "uuid" => String?,
+      "version" => String,
+      "vendor" => Vendor
+    }.to_json
   end
 
 end

--- a/src/couchdb/response/server_info.cr
+++ b/src/couchdb/response/server_info.cr
@@ -3,19 +3,17 @@ require "json"
 module CouchDB::Response
 
   class Vendor
-    {
-      "name" => String,
-      "version" => String?
-    }.to_json
+    include JSON::Serializable
+    property name : String
+    property version : String
   end
 
   class ServerInfo
-    {
-      "couchdb" => String,
-      "uuid" => String?,
-      "version" => String,
-      "vendor" => Vendor
-    }.to_json
+    include JSON::Serializable
+    property couchdb : String
+    property uuid : String
+    property version : String
+    property vendor : Vendor
   end
 
 end

--- a/src/couchdb/response/status.cr
+++ b/src/couchdb/response/status.cr
@@ -5,11 +5,11 @@ module CouchDB::Response
 
   class Status
 
-    JSON.mapping(
-      ok: Bool?,
-      error: String?,
-      reason: String?
-    )
+    {
+      "ok" => Bool?,
+      "error" => String?,
+      "reason" => String?
+    }.to_json
 
     def ok? : Bool
       ok.nil? ? false : ok.not_nil!
@@ -27,13 +27,13 @@ module CouchDB::Response
 
   class DocumentStatus < Status
 
-    JSON.mapping(
-      ok: Bool?,
-      error: String?,
-      reason: String?,
-      id: String?,
-      rev: String?
-    )
+    {
+      "ok" => Bool?,
+      "error" => String?,
+      "reason" => String?,
+      "id" => String?,
+      "rev" => String?
+    }.to_json
 
   end
 

--- a/src/couchdb/response/status.cr
+++ b/src/couchdb/response/status.cr
@@ -4,13 +4,11 @@ require "json"
 module CouchDB::Response
 
   class Status
-
-    {
-      "ok" => Bool?,
-      "error" => String?,
-      "reason" => String?
-    }.to_json
-
+    include JSON::Serializable
+    property ok : Bool?
+    property error : String?
+    property reason : String?
+    
     def ok? : Bool
       ok.nil? ? false : ok.not_nil!
     end
@@ -26,15 +24,12 @@ module CouchDB::Response
   end
 
   class DocumentStatus < Status
-
-    {
-      "ok" => Bool?,
-      "error" => String?,
-      "reason" => String?,
-      "id" => String?,
-      "rev" => String?
-    }.to_json
-
+    include JSON::Serializable
+    property ok : Bool?
+    property error : String?
+    property reason : String?
+    property id : String?
+    property rev : String?
   end
 
 end

--- a/src/couchdb/version.cr
+++ b/src/couchdb/version.cr
@@ -1,3 +1,3 @@
 module CouchDB
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end


### PR DESCRIPTION
Hello, I updated this shard for Crystal 0.35.1
Basically, the JSON.mapping is out, and it's now just extending each class with JSON::Serializable

I added one more method for creating a document with a custom (out of band) ID, which I need for my work:
```
    def create_document_custom_id(database, object, id) : Response::DocumentStatus
      Response::DocumentStatus.from_json(
        put(URL::DOC % {database, id}, body: object.to_json)
      )
    end 
```
I confess to not having added a unit test for this method, which I will do at some point.